### PR TITLE
Fix focus on list instead of first item on Windows

### DIFF
--- a/RepoZ.App.Win/MainWindow.xaml.cs
+++ b/RepoZ.App.Win/MainWindow.xaml.cs
@@ -343,10 +343,14 @@ namespace RepoZ.App.Win
 
 		private void txtFilter_Finish(object sender, EventArgs e)
 		{
-			lstRepositories.Focus();
-			if (lstRepositories.Items.Count > 0)
-				lstRepositories.SelectedIndex = 0;
-		}
+            lstRepositories.Focus();
+            if (lstRepositories.Items.Count > 0)
+            {
+                lstRepositories.SelectedIndex = 0;
+                var item = (ListBoxItem)lstRepositories.ItemContainerGenerator.ContainerFromIndex(0);
+                item?.Focus();
+            }
+        }
 
 		private string GetHelp(StatusCharacterMap statusCharacterMap)
 		{


### PR DESCRIPTION
This saves extra key press when you want not first repo in list.

Before:
![repoz2](https://user-images.githubusercontent.com/1058537/73653199-b80cab00-4699-11ea-8bf6-6b10b41450d0.gif)
After:
![repoz3](https://user-images.githubusercontent.com/1058537/73653206-bcd15f00-4699-11ea-8910-cc3d45d4214a.gif)
