### PR TITLE
Open sln files

### DIFF
--- a/RepoZ.Api.Win/Git/WindowsRepositoryActionProvider.cs
+++ b/RepoZ.Api.Win/Git/WindowsRepositoryActionProvider.cs
@@ -24,7 +24,7 @@ namespace RepoZ.Api.Win.IO
 		private string _bashLocation;
 		private string _codeLocation;
 
-        public WindowsRepositoryActionProvider(
+		public WindowsRepositoryActionProvider(
 			IRepositoryWriter repositoryWriter,
 			IRepositoryMonitor repositoryMonitor,
 			IErrorHandler errorHandler,
@@ -79,9 +79,9 @@ namespace RepoZ.Api.Win.IO
 				if (hasCode)
 					yield return CreateProcessRunnerAction(_translationService.Translate("Open in Visual Studio Code"), codeExecutable, singleRepository.SafePath);
 
-                var slnFiles = TryFindVisualStudioSlnFiles(singleRepository);
-                foreach (var slnFile in slnFiles)
-                {
+				var slnFiles = TryFindVisualStudioSlnFiles(singleRepository);
+				foreach (var slnFile in slnFiles)
+				{
 					yield return CreateProcessRunnerAction(_translationService.Translate("Open {0}", slnFile), Path.Combine(singleRepository.Path, slnFile));
 				}
 
@@ -108,7 +108,7 @@ namespace RepoZ.Api.Win.IO
 			yield return CreateActionForMultipleRepositories(_translationService.Translate("Ignore"), repositories, r => _repositoryMonitor.IgnoreByPath(r.Path), beginGroup: true);
 		}
 
-        private RepositoryAction CreateProcessRunnerAction(string name, string process, string arguments = "")
+		private RepositoryAction CreateProcessRunnerAction(string name, string process, string arguments = "")
 		{
 			return new RepositoryAction()
 			{
@@ -117,7 +117,7 @@ namespace RepoZ.Api.Win.IO
 			};
 		}
 
-        private RepositoryAction CreateActionForMultipleRepositories(string name,
+		private RepositoryAction CreateActionForMultipleRepositories(string name,
 			IEnumerable<Repository> repositories,
 			Action<Repository> action,
 			bool beginGroup = false,
@@ -141,7 +141,7 @@ namespace RepoZ.Api.Win.IO
 			};
 		}
 
-        private void SafelyExecute(Action<Repository> action, Repository repository)
+		private void SafelyExecute(Action<Repository> action, Repository repository)
 		{
 			try
 			{
@@ -153,7 +153,7 @@ namespace RepoZ.Api.Win.IO
 			}
 		}
 
-        private void StartProcess(string process, string arguments)
+		private void StartProcess(string process, string arguments)
 		{
 			try
 			{
@@ -166,9 +166,9 @@ namespace RepoZ.Api.Win.IO
 			}
 		}
 
-        private bool HasWindowsTerminal() => !string.IsNullOrEmpty(TryFindWindowsTerminal());
+		private bool HasWindowsTerminal() => !string.IsNullOrEmpty(TryFindWindowsTerminal());
 
-        private string TryFindWindowsTerminal()
+		private string TryFindWindowsTerminal()
 		{
 			if (_windowsTerminalLocation == null)
 			{
@@ -179,7 +179,7 @@ namespace RepoZ.Api.Win.IO
 			return _windowsTerminalLocation;
 		}
 
-        private string TryFindBash()
+		private string TryFindBash()
 		{
 			if (_bashLocation == null)
 			{
@@ -201,7 +201,7 @@ namespace RepoZ.Api.Win.IO
 			return _bashLocation;
 		}
 
-        private string TryFindCode()
+		private string TryFindCode()
 		{
 			if (_codeLocation == null)
 			{
@@ -223,12 +223,10 @@ namespace RepoZ.Api.Win.IO
 			return _codeLocation;
 		}
 
-        private IEnumerable<string> TryFindVisualStudioSlnFiles(Repository repository)
-        {
-            var directoryInfo = new DirectoryInfo(repository.Path);
-
-            var slnFiles = directoryInfo.GetFiles("*.sln");
-            return slnFiles.Select(f => f.Name);
-        }
+		private IEnumerable<string> TryFindVisualStudioSlnFiles(Repository repository)
+		{
+			var directoryInfo = new DirectoryInfo(repository.Path);
+			return directoryInfo.GetFiles("*.sln").Select(f => f.Name);
+		}
     }
 }

--- a/RepoZ.Api.Win/Git/WindowsRepositoryActionProvider.cs
+++ b/RepoZ.Api.Win/Git/WindowsRepositoryActionProvider.cs
@@ -24,7 +24,7 @@ namespace RepoZ.Api.Win.IO
 		private string _bashLocation;
 		private string _codeLocation;
 
-		public WindowsRepositoryActionProvider(
+        public WindowsRepositoryActionProvider(
 			IRepositoryWriter repositoryWriter,
 			IRepositoryMonitor repositoryMonitor,
 			IErrorHandler errorHandler,
@@ -79,6 +79,12 @@ namespace RepoZ.Api.Win.IO
 				if (hasCode)
 					yield return CreateProcessRunnerAction(_translationService.Translate("Open in Visual Studio Code"), codeExecutable, singleRepository.SafePath);
 
+                var slnFiles = TryFindVisualStudioSlnFiles(singleRepository);
+                foreach (var slnFile in slnFiles)
+                {
+					yield return CreateProcessRunnerAction(_translationService.Translate("Open {0}", slnFile), Path.Combine(singleRepository.Path, slnFile));
+				}
+
 			}
 
 			yield return CreateActionForMultipleRepositories(_translationService.Translate("Fetch"), repositories, _repositoryWriter.Fetch, beginGroup: true, executionCausesSynchronizing: true);
@@ -102,7 +108,7 @@ namespace RepoZ.Api.Win.IO
 			yield return CreateActionForMultipleRepositories(_translationService.Translate("Ignore"), repositories, r => _repositoryMonitor.IgnoreByPath(r.Path), beginGroup: true);
 		}
 
-		private RepositoryAction CreateProcessRunnerAction(string name, string process, string arguments = "")
+        private RepositoryAction CreateProcessRunnerAction(string name, string process, string arguments = "")
 		{
 			return new RepositoryAction()
 			{
@@ -111,7 +117,7 @@ namespace RepoZ.Api.Win.IO
 			};
 		}
 
-		private RepositoryAction CreateActionForMultipleRepositories(string name,
+        private RepositoryAction CreateActionForMultipleRepositories(string name,
 			IEnumerable<Repository> repositories,
 			Action<Repository> action,
 			bool beginGroup = false,
@@ -135,7 +141,7 @@ namespace RepoZ.Api.Win.IO
 			};
 		}
 
-		private void SafelyExecute(Action<Repository> action, Repository repository)
+        private void SafelyExecute(Action<Repository> action, Repository repository)
 		{
 			try
 			{
@@ -147,7 +153,7 @@ namespace RepoZ.Api.Win.IO
 			}
 		}
 
-		private void StartProcess(string process, string arguments)
+        private void StartProcess(string process, string arguments)
 		{
 			try
 			{
@@ -160,9 +166,9 @@ namespace RepoZ.Api.Win.IO
 			}
 		}
 
-		private bool HasWindowsTerminal() => !string.IsNullOrEmpty(TryFindWindowsTerminal());
+        private bool HasWindowsTerminal() => !string.IsNullOrEmpty(TryFindWindowsTerminal());
 
-		private string TryFindWindowsTerminal()
+        private string TryFindWindowsTerminal()
 		{
 			if (_windowsTerminalLocation == null)
 			{
@@ -173,7 +179,7 @@ namespace RepoZ.Api.Win.IO
 			return _windowsTerminalLocation;
 		}
 
-		private string TryFindBash()
+        private string TryFindBash()
 		{
 			if (_bashLocation == null)
 			{
@@ -195,7 +201,7 @@ namespace RepoZ.Api.Win.IO
 			return _bashLocation;
 		}
 
-		private string TryFindCode()
+        private string TryFindCode()
 		{
 			if (_codeLocation == null)
 			{
@@ -216,5 +222,13 @@ namespace RepoZ.Api.Win.IO
 
 			return _codeLocation;
 		}
-	}
+
+        private IEnumerable<string> TryFindVisualStudioSlnFiles(Repository repository)
+        {
+            var directoryInfo = new DirectoryInfo(repository.Path);
+
+            var slnFiles = directoryInfo.GetFiles("*.sln");
+            return slnFiles.Select(f => f.Name);
+        }
+    }
 }

--- a/RepoZ.App.Win/i18n/de-DE.xaml
+++ b/RepoZ.App.Win/i18n/de-DE.xaml
@@ -37,8 +37,8 @@ Alternativ, kann der Computer auch über das Menü oben rechts nach Repositories
 	<system:String x:Key="Open in Git Bash">In Git Bash öffnen</system:String>
 	<system:String x:Key="Open in Finder">In Finder öffnen</system:String>
 	<system:String x:Key="Open in Terminal">Im Terminal öffnen</system:String>
-    <system:String x:Key="Open {0}">Öffnen {0}</system:String>
-    <system:String x:Key="Fetch">Git Fetch</system:String>
+	<system:String x:Key="Open {0}">Öffnen {0}</system:String>
+	<system:String x:Key="Fetch">Git Fetch</system:String>
 	<system:String x:Key="Pull">Git Pull</system:String>
 	<system:String x:Key="Push">Git Push</system:String>
 	<system:String x:Key="Checkout">Branch wechseln</system:String>

--- a/RepoZ.App.Win/i18n/de-DE.xaml
+++ b/RepoZ.App.Win/i18n/de-DE.xaml
@@ -37,7 +37,8 @@ Alternativ, kann der Computer auch über das Menü oben rechts nach Repositories
 	<system:String x:Key="Open in Git Bash">In Git Bash öffnen</system:String>
 	<system:String x:Key="Open in Finder">In Finder öffnen</system:String>
 	<system:String x:Key="Open in Terminal">Im Terminal öffnen</system:String>
-	<system:String x:Key="Fetch">Git Fetch</system:String>
+    <system:String x:Key="Open {0}">Öffnen {0}</system:String>
+    <system:String x:Key="Fetch">Git Fetch</system:String>
 	<system:String x:Key="Pull">Git Pull</system:String>
 	<system:String x:Key="Push">Git Push</system:String>
 	<system:String x:Key="Checkout">Branch wechseln</system:String>

--- a/RepoZ.App.Win/i18n/de-DE.xaml
+++ b/RepoZ.App.Win/i18n/de-DE.xaml
@@ -37,7 +37,7 @@ Alternativ, kann der Computer auch über das Menü oben rechts nach Repositories
 	<system:String x:Key="Open in Git Bash">In Git Bash öffnen</system:String>
 	<system:String x:Key="Open in Finder">In Finder öffnen</system:String>
 	<system:String x:Key="Open in Terminal">Im Terminal öffnen</system:String>
-	<system:String x:Key="Open {0}">Öffnen {0}</system:String>
+    <system:String x:Key="Open {0}">{0} öffnen</system:String>
 	<system:String x:Key="Fetch">Git Fetch</system:String>
 	<system:String x:Key="Pull">Git Pull</system:String>
 	<system:String x:Key="Push">Git Push</system:String>

--- a/RepoZ.App.Win/i18n/en-us.xaml
+++ b/RepoZ.App.Win/i18n/en-us.xaml
@@ -37,7 +37,8 @@ Alternatively, you can scan your computer manually for repositories in the setti
 	<system:String x:Key="Open in Visual Studio Code">Open in Visual Studio Code</system:String>
 	<system:String x:Key="Open in Git Bash">Open in Git Bash</system:String>
 	<system:String x:Key="Open in Finder">Open in Finder</system:String>
-	<system:String x:Key="Open in Terminal">Open in Terminal</system:String>
+    <system:String x:Key="Open in Terminal">Open in Terminal</system:String>
+    <system:String x:Key="Open {0}">Open {0}</system:String>
 	<system:String x:Key="Fetch">Fetch</system:String>
 	<system:String x:Key="Pull">Pull</system:String>
 	<system:String x:Key="Push">Push</system:String>

--- a/RepoZ.App.Win/i18n/en-us.xaml
+++ b/RepoZ.App.Win/i18n/en-us.xaml
@@ -37,8 +37,8 @@ Alternatively, you can scan your computer manually for repositories in the setti
 	<system:String x:Key="Open in Visual Studio Code">Open in Visual Studio Code</system:String>
 	<system:String x:Key="Open in Git Bash">Open in Git Bash</system:String>
 	<system:String x:Key="Open in Finder">Open in Finder</system:String>
-    <system:String x:Key="Open in Terminal">Open in Terminal</system:String>
-    <system:String x:Key="Open {0}">Open {0}</system:String>
+	<system:String x:Key="Open in Terminal">Open in Terminal</system:String>
+	<system:String x:Key="Open {0}">Open {0}</system:String>
 	<system:String x:Key="Fetch">Fetch</system:String>
 	<system:String x:Key="Pull">Pull</system:String>
 	<system:String x:Key="Push">Push</system:String>

--- a/RepoZ.App.Win/i18n/zh-cn.xaml
+++ b/RepoZ.App.Win/i18n/zh-cn.xaml
@@ -37,6 +37,7 @@
     <system:String x:Key="Open in Git Bash">在 Git Bash 中打开</system:String>
     <system:String x:Key="Open in Finder">在 Finder 中打开</system:String>
     <system:String x:Key="Open in Terminal">在 Terminal 中打开</system:String>
+    <system:String x:Key="Open {0}">打开 {0}</system:String>
     <system:String x:Key="Fetch">获取</system:String>
     <system:String x:Key="Pull">拉取</system:String>
     <system:String x:Key="Push">推送</system:String>


### PR DESCRIPTION
Checks the root directory of the repository for `*,sln` files and adds a "Open <sln file>" option to the context menu, allowing the user to open the solution directly in Visual Studio.  
![image](https://user-images.githubusercontent.com/121837/88778279-9bed5080-d188-11ea-9b5d-8f75c462dd50.png)

The motivation was that we have several repos and this provides a nice shortcut to finding a repo and opening the solution directly in Visual Studio. 

It just starts the file directly since it should be associated with Visual Studio and should open in the correct VS version installed on the user's computer. 

I guess it could be expanded on by looking in subfolders (worried about performance), some common subfolders (for instance `/src/`) or perhaps even some config. Wanted to start small and see if you want this in your app and maybe expand on it later if there's any interest. 

Could probably be used on the Mac version as well with Visual Studio for Mac, but I don't have a Mac so I don't know if it would work with just starting the `.sln` file. 