### PR TITLE
fix: Sendkey fails when target has no windows handle

### DIFF
--- a/grr/ConsoleExtensions.cs
+++ b/grr/ConsoleExtensions.cs
@@ -56,7 +56,13 @@ namespace grr
         var process = Process.GetProcessById(id);
         while ( process.MainWindowHandle == IntPtr.Zero )
         {
+          var lastProcess = process;
           process = GetParentProcess(process.Handle);
+          if ( lastProcess == process )
+          {
+						// Better a result without window handle than an infinite loop
+            break;
+          }
         }
         return process;
       }


### PR DESCRIPTION
Sendkey can only send keys to a process if it has a windows handle.
That happens when grr itself is the target process or it is called from inside ConEmu, WindowsTerminal or other console emulators. It even happens when a shell is run inside a shell.
Sending the keys to the first parent with windows handle causes insertion of the keys into the current shell.