### PR TITLE
Add SourceTree option in Windows Action Provider

### DIFF
--- a/RepoZ.Api.Win/Git/WindowsRepositoryActionProvider.cs
+++ b/RepoZ.Api.Win/Git/WindowsRepositoryActionProvider.cs
@@ -18,6 +18,7 @@ namespace RepoZ.Api.Win.IO
 
 		private string _windowsTerminalLocation;
 		private string _codeLocation;
+		private string _sourceTreeLocation;
 
 		public WindowsRepositoryActionProvider(
 			IRepositoryWriter repositoryWriter,
@@ -64,6 +65,12 @@ namespace RepoZ.Api.Win.IO
 					yield return CreateProcessRunnerAction(_translationService.Translate("Open in Visual Studio Code"), codeExecutable, '"' + singleRepository.SafePath + '"');
 
 				yield return CreateFileActionSubMenu(singleRepository, _translationService.Translate("Open Visual Studio solutions"), "*.sln");
+
+				var sourceTreeExecutable = TryFindSourceTree();
+				var hasSourceTree = !string.IsNullOrEmpty(sourceTreeExecutable);
+				if (hasSourceTree)
+					yield return CreateProcessRunnerAction(_translationService.Translate("Open in SourceTree"), sourceTreeExecutable, "-f " + '"' + singleRepository.SafePath + '"');
+
 
 				yield return CreateBrowseRemoteAction(singleRepository);
 			}
@@ -162,6 +169,19 @@ namespace RepoZ.Api.Win.IO
 			}
 
 			return _windowsTerminalLocation;
+		}
+
+		private string TryFindSourceTree()
+		{
+			if (_sourceTreeLocation == null)
+			{
+				var folder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+				var executable = Path.Combine(folder, "SourceTree", "SourceTree.exe");
+
+				_sourceTreeLocation = File.Exists(executable) ? executable : string.Empty;
+			}
+
+			return _sourceTreeLocation;
 		}
 
 		private string TryFindCode()

--- a/RepoZ.Api.Win/Git/WindowsRepositoryActionProvider.cs
+++ b/RepoZ.Api.Win/Git/WindowsRepositoryActionProvider.cs
@@ -69,7 +69,7 @@ namespace RepoZ.Api.Win.IO
 				var sourceTreeExecutable = TryFindSourceTree();
 				var hasSourceTree = !string.IsNullOrEmpty(sourceTreeExecutable);
 				if (hasSourceTree)
-					yield return CreateProcessRunnerAction(_translationService.Translate("Open in SourceTree"), sourceTreeExecutable, "-f " + '"' + singleRepository.SafePath + '"');
+					yield return CreateProcessRunnerAction(_translationService.Translate("Open in Sourcetree"), sourceTreeExecutable, "-f " + '"' + singleRepository.SafePath + '"');
 
 
 				yield return CreateBrowseRemoteAction(singleRepository);

--- a/RepoZ.App.Win/i18n/de-DE.xaml
+++ b/RepoZ.App.Win/i18n/de-DE.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:RepoZ.App.Win.i18n"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
@@ -38,7 +38,7 @@ Alternativ, kann der Computer auch über das Menü oben rechts nach Repositories
 	<system:String x:Key="Open in Git Bash">In Git Bash öffnen</system:String>
 	<system:String x:Key="Open in Finder">In Finder öffnen</system:String>
 	<system:String x:Key="Open in Terminal">Im Terminal öffnen</system:String>
-	<system:String x:Key="Open in Sourcetree">Im Sourcetree öffnen</system:String>	
+	<system:String x:Key="Open in Sourcetree">In Sourcetree öffnen</system:String>	
     <system:String x:Key="Open {0}">{0} öffnen</system:String>
 	<system:String x:Key="Browse remote">Remote-Repository öffnen</system:String>
 	<system:String x:Key="Fetch">Git Fetch</system:String>

--- a/RepoZ.App.Win/i18n/de-DE.xaml
+++ b/RepoZ.App.Win/i18n/de-DE.xaml
@@ -38,6 +38,7 @@ Alternativ, kann der Computer auch über das Menü oben rechts nach Repositories
 	<system:String x:Key="Open in Git Bash">In Git Bash öffnen</system:String>
 	<system:String x:Key="Open in Finder">In Finder öffnen</system:String>
 	<system:String x:Key="Open in Terminal">Im Terminal öffnen</system:String>
+	<system:String x:Key="Open in Sourcetree">Im Sourcetree öffnen</system:String>	
     <system:String x:Key="Open {0}">{0} öffnen</system:String>
 	<system:String x:Key="Browse remote">Remote-Repository öffnen</system:String>
 	<system:String x:Key="Fetch">Git Fetch</system:String>

--- a/RepoZ.App.Win/i18n/en-us.xaml
+++ b/RepoZ.App.Win/i18n/en-us.xaml
@@ -39,6 +39,7 @@ Alternatively, you can scan your computer manually for repositories in the setti
 	<system:String x:Key="Open in Git Bash">Open in Git Bash</system:String>
 	<system:String x:Key="Open in Finder">Open in Finder</system:String>
 	<system:String x:Key="Open in Terminal">Open in Terminal</system:String>
+	<system:String x:Key="Open in Sourcetree">Open in Sourcetree</system:String>
 	<system:String x:Key="Open {0}">Open {0}</system:String>
 	<system:String x:Key="Browse remote">Browse remote repository</system:String>
 	<system:String x:Key="Fetch">Fetch</system:String>

--- a/RepoZ.App.Win/i18n/zh-cn.xaml
+++ b/RepoZ.App.Win/i18n/zh-cn.xaml
@@ -38,6 +38,7 @@
 	<system:String x:Key="Open in Git Bash">在 Git Bash 中打开</system:String>
     <system:String x:Key="Open in Finder">在 Finder 中打开</system:String>
     <system:String x:Key="Open in Terminal">在 Terminal 中打开</system:String>
+    <system:String x:Key="Open in Sourcetree">Open in Sourcetree</system:String>
     <system:String x:Key="Open {0}">打开 {0}</system:String>
 	<system:String x:Key="Browse remote">Browse remote repository</system:String>
     <system:String x:Key="Fetch">获取</system:String>


### PR DESCRIPTION
Just found your project but I really like this tool. I also use SourceTree as a visual git client and added an extra action provider to start SourceTree with the current git repo selected.

I am aware of #114 to make this configurable but until then... you might want to add this.