### PR TITLE
Added alternate possible location of SourceTree executable

### DIFF
--- a/RepoZ.Api.Win/Git/WindowsRepositoryActionProvider.cs
+++ b/RepoZ.Api.Win/Git/WindowsRepositoryActionProvider.cs
@@ -175,12 +175,22 @@ namespace RepoZ.Api.Win.IO
 		{
 			if (_sourceTreeLocation == null)
 			{
+				//Try : Installed in the user profile
 				var folder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 				var executable = Path.Combine(folder, "SourceTree", "SourceTree.exe");
 
 				_sourceTreeLocation = File.Exists(executable) ? executable : string.Empty;
-			}
 
+				//Try: Installed in Program files x86
+				if (string.IsNullOrEmpty(_sourceTreeLocation))
+				{
+					folder = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+					folder = Path.Combine(folder, "Atlassian");
+					executable = Path.Combine(folder, "SourceTree", "SourceTree.exe");
+
+					_sourceTreeLocation = File.Exists(executable) ? executable : string.Empty;
+				}
+			}
 			return _sourceTreeLocation;
 		}
 


### PR DESCRIPTION
When installed "system wide" it ends up not in the user profile, but at "Program Files x86/Atlassian/SourceTree/". This is the default location if installed through Chocolatey using the silent installer.

Modeled second try like it was done for VS Code. This ensures we only look once per run of application.